### PR TITLE
Add basic pattern detection module

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,23 @@ days = 1
 time_start = int(datetime.now().timestamp())
 time_end = time_start - 86400 * days
 df = api.get_history(
-    pair, 
-    period, 
-    start_time=time_start, 
+    pair,
+    period,
+    start_time=time_start,
     end_time=time_end)
+```
+
+### Pattern Detection Example
+```python
+from pocketoptionapi.ml.pattern_detector import MultiSymbolPatternDetector, TickData
+
+# initialise detector for two symbols
+detector = MultiSymbolPatternDetector(["EURUSD", "GBPUSD"])
+
+# add ticks in your data feed loop
+tick = TickData(timestamp=time.time(), price=1.2345)
+result = detector.add_tick("EURUSD", tick)
+print(result)
 ```
 
 ## 🔧 Settings

--- a/examples/pattern_dashboard.py
+++ b/examples/pattern_dashboard.py
@@ -1,0 +1,43 @@
+"""Example Dash app for visualising pattern detection results."""
+
+import random
+from datetime import datetime
+
+import dash
+from dash import dcc, html
+import plotly.graph_objs as go
+
+from pocketoptionapi.ml.pattern_detector import MultiSymbolPatternDetector, TickData
+
+app = dash.Dash(__name__)
+
+detector = MultiSymbolPatternDetector(["EURUSD", "GBPUSD"])
+
+def generate_tick(symbol: str) -> TickData:
+    """Simulate tick data for demonstration purposes."""
+    return TickData(timestamp=datetime.utcnow().timestamp(), price=random.uniform(1.0, 1.5))
+
+app.layout = html.Div([
+    dcc.Graph(id="price-chart"),
+    dcc.Interval(id="interval", interval=1000, n_intervals=0)
+])
+
+@app.callback(
+    dash.dependencies.Output("price-chart", "figure"),
+    [dash.dependencies.Input("interval", "n_intervals")]
+)
+def update_chart(n):
+    tick = generate_tick("EURUSD")
+    result = detector.add_tick("EURUSD", tick)
+    prices = [t.price for t in detector.buffers["EURUSD"]]
+    times = [datetime.fromtimestamp(t.timestamp) for t in detector.buffers["EURUSD"]]
+    return {
+        "data": [
+            go.Scatter(x=times, y=prices, mode="lines", name="EURUSD"),
+            go.Scatter(x=[times[-1]], y=[result["prediction"]], mode="markers", name="Prediction")
+        ],
+        "layout": go.Layout(title="EURUSD Price with Prediction")
+    }
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/pocketoptionapi/__init__.py
+++ b/pocketoptionapi/__init__.py
@@ -1,5 +1,6 @@
 from .api import PocketOptionAPI
+from .ml.pattern_detector import MultiSymbolPatternDetector, TickData
 
 __version__ = "0.1.0"
 
-__all__ = ['PocketOptionAPI']
+__all__ = ['PocketOptionAPI', 'MultiSymbolPatternDetector', 'TickData']

--- a/pocketoptionapi/ml/pattern_detector.py
+++ b/pocketoptionapi/ml/pattern_detector.py
@@ -1,0 +1,56 @@
+"""Machine learning utilities for multi-symbol pattern detection and price prediction."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import IsolationForest
+from sklearn.linear_model import LinearRegression
+
+
+@dataclass
+class TickData:
+    """Simple structure for tick data."""
+
+    timestamp: float
+    price: float
+    volume: Optional[float] = None
+
+
+class MultiSymbolPatternDetector:
+    """Basic framework for pattern detection and price prediction."""
+
+    def __init__(self, symbols: List[str], window: int = 100):
+        self.symbols = symbols
+        self.window = window
+        self.buffers: Dict[str, deque] = {symbol: deque(maxlen=window) for symbol in symbols}
+        self.models: Dict[str, IsolationForest] = {symbol: IsolationForest(contamination=0.01) for symbol in symbols}
+        self.regressors: Dict[str, LinearRegression] = {symbol: LinearRegression() for symbol in symbols}
+        self.trained: Dict[str, bool] = {symbol: False for symbol in symbols}
+
+    def add_tick(self, symbol: str, tick: TickData) -> Dict[str, float]:
+        """Add tick data and return detection results."""
+        if symbol not in self.symbols:
+            raise ValueError(f"Unknown symbol {symbol}")
+        buffer = self.buffers[symbol]
+        buffer.append(tick)
+        result = {
+            "anomaly_score": 0.0,
+            "prediction": tick.price,
+        }
+        if len(buffer) >= self.window:
+            df = pd.DataFrame(buffer)
+            X = df[["price"]].values
+            if not self.trained[symbol]:
+                self.models[symbol].fit(X)
+                self.regressors[symbol].fit(np.arange(len(X)).reshape(-1, 1), X)
+                self.trained[symbol] = True
+            anomaly_score = -self.models[symbol].score_samples(X)[-1]
+            next_index = np.array([[len(X)]])
+            prediction = float(self.regressors[symbol].predict(next_index)[0])
+            result.update({"anomaly_score": float(anomaly_score), "prediction": prediction})
+        return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ tzlocal>=5.1
 websockets>=12.0
 pandas>=2.0.3
 colorama>=0.4.6
+scikit-learn>=1.3.2
+dash>=2.9.0
+plotly>=5.17.0


### PR DESCRIPTION
## Summary
- add multi-symbol pattern detection utilities
- expose pattern detection classes in package
- provide basic Dash dashboard example
- document usage example in README
- add new dependencies for ML and visualization

## Testing
- `pytest -q`
- `pip install -r requirements.txt`
- `pip install -e .`


------
https://chatgpt.com/codex/tasks/task_e_68703a14a25c832bb1af34832c3bd05f